### PR TITLE
Add handshake state machine for UDP chat

### DIFF
--- a/src/packet/ChatApp.java
+++ b/src/packet/ChatApp.java
@@ -9,6 +9,10 @@ import java.net.UnknownHostException;
 import java.util.Scanner;
 import java.util.zip.CRC32;
 
+import static packet.PacketType.*;
+
+import java.io.IOException;
+
 public class ChatApp extends Thread {
     private final RoutingManager routingManager;
     private final DatagramSocket chatSocket;
@@ -16,12 +20,17 @@ public class ChatApp extends Thread {
     private String activeChatPartnerAddress; // Speichert die IP:Port des Chatpartners als String
     private int messageIdCounter = 0;
     private String ownAddress; // Die eigene Adresse für die Anzeige in Nachrichten
+    private ConnectionState connectionState = ConnectionState.DISCONNECTED;
+    private InetAddress partnerIp;
+    private int partnerPort;
 
     public ChatApp(RoutingManager routingManager, int chatPort) throws SocketException, UnknownHostException {
         this.routingManager = routingManager;
         this.chatSocket = new DatagramSocket(chatPort);
         this.chatPort = chatPort;
         this.activeChatPartnerAddress = null;
+        this.partnerIp = null;
+        this.partnerPort = -1;
         // Speichere die eigene Adresse für die Nachrichten-Signatur
         this.ownAddress = InetAddress.getLocalHost().getHostAddress() + ":" + this.chatPort;
     }
@@ -29,7 +38,7 @@ public class ChatApp extends Thread {
     @Override
     public void run() {
         // Starte Receiver...
-        UdpReceiver receiver = new UdpReceiver(chatSocket, 4, routingManager);
+        UdpReceiver receiver = new UdpReceiver(chatSocket, 4, routingManager, this);
         receiver.start();
 
         System.out.println("Chat-Anwendung gestartet auf " + ownAddress);
@@ -60,21 +69,33 @@ public class ChatApp extends Thread {
                 if (parts.length < 2) {
                     System.out.println("FEHLER: Bitte eine Adresse angeben. Verwendung: /chat <IP:Port>");
                 } else {
-                    activeChatPartnerAddress = parts[1];
-                    System.out.println("Du sprichst jetzt mit '" + activeChatPartnerAddress + "'.");
+                    initiateHandshake(parts[1]);
                 }
                 break;
             case "/msg":
                 if (parts.length < 3) {
                     System.out.println("FEHLER: Verwendung: /msg <IP:Port> <Nachricht>");
                 } else {
-                    sendMessage(parts[1], parts[2]);
+                    if (connectionState != ConnectionState.CONNECTED || !parts[1].equals(activeChatPartnerAddress)) {
+                        initiateHandshake(parts[1]);
+                        System.out.println("Handshake wird durchgefuehrt. Bitte erneut senden.");
+                    } else {
+                        sendMessage(parts[1], parts[2]);
+                    }
                 }
                 break;
             case "/list":
                 routingManager.printKnownNodes(); // Ruft die neue, einfache Methode auf
                 break;
             case "/quit":
+                if (connectionState == ConnectionState.CONNECTED) {
+                    try {
+                        sendControlPacket(FIN, partnerIp, partnerPort);
+                        connectionState = ConnectionState.FIN_WAIT;
+                    } catch (Exception e) {
+                        // ignore
+                    }
+                }
                 System.out.println("Anwendung wird beendet...");
                 chatSocket.close();
                 System.exit(0);
@@ -90,7 +111,11 @@ public class ChatApp extends Thread {
 
     private void handleMessageInput(String messageText) {
         if (activeChatPartnerAddress != null) {
-            sendMessage(activeChatPartnerAddress, messageText);
+            if (connectionState == ConnectionState.CONNECTED) {
+                sendMessage(activeChatPartnerAddress, messageText);
+            } else {
+                System.out.println("Keine aktive Verbindung. Bitte warte auf den Handshake.");
+            }
         } else {
             System.out.println("Kein aktiver Chatpartner. Nutze '/chat <IP:Port>' oder '/msg <IP:Port> <Nachricht>'.");
         }
@@ -109,6 +134,11 @@ public class ChatApp extends Thread {
             }
             InetAddress destIp = InetAddress.getByName(addrParts[0]);
             int destPort = Integer.parseInt(addrParts[1]);
+
+            if (connectionState != ConnectionState.CONNECTED) {
+                System.out.println("Keine Verbindung. Fuehre zuerst /chat fuer den Handshake aus.");
+                return;
+            }
 
             // Payload bauen (ohne Namen)
             MessagePayload payload = new MessagePayload(
@@ -152,5 +182,98 @@ public class ChatApp extends Thread {
         CRC32 crc32 = new CRC32();
         crc32.update(data);
         return (int) crc32.getValue();
+    }
+
+    private void initiateHandshake(String address) {
+        try {
+            String[] parts = address.split(":");
+            partnerIp = InetAddress.getByName(parts[0]);
+            partnerPort = Integer.parseInt(parts[1]);
+            activeChatPartnerAddress = address;
+            sendControlPacket(SYN, partnerIp, partnerPort);
+            connectionState = ConnectionState.SYN_SENT;
+            System.out.println("Handshake gestartet mit " + address);
+        } catch (Exception e) {
+            System.out.println("FEHLER beim Handshake: " + e.getMessage());
+        }
+    }
+
+    private void sendControlPacket(PacketType type, InetAddress ip, int port) throws IOException {
+        EmptyPayload payload = new EmptyPayload();
+        int checksum = calculateChecksum(payload.serialize());
+        PacketHeader header = new PacketHeader(
+                InetAddress.getLocalHost(), this.chatPort,
+                ip, port,
+                type,
+                0,
+                checksum
+        );
+        Packet p = new Packet(header, payload);
+        routingManager.sendMessageTo(chatSocket, ip, port, p);
+    }
+
+    public synchronized void onPacketReceived(Packet packet) {
+        PacketHeader header = packet.getHeader();
+        String source = header.getSourceIp().getHostAddress() + ":" + header.getSourcePort();
+        switch (header.getType()) {
+            case SYN:
+                if (connectionState == ConnectionState.DISCONNECTED) {
+                    partnerIp = header.getSourceIp();
+                    partnerPort = header.getSourcePort();
+                    activeChatPartnerAddress = source;
+                    try {
+                        sendControlPacket(SYN_ACK, partnerIp, partnerPort);
+                        connectionState = ConnectionState.SYN_RECEIVED;
+                    } catch (IOException e) {
+                        // ignore
+                    }
+                    System.out.println("SYN empfangen von " + source);
+                }
+                break;
+            case SYN_ACK:
+                if (connectionState == ConnectionState.SYN_SENT) {
+                    try {
+                        sendControlPacket(ACK, partnerIp, partnerPort);
+                        connectionState = ConnectionState.CONNECTED;
+                    } catch (IOException e) {
+                        // ignore
+                    }
+                    System.out.println("Verbindung hergestellt mit " + activeChatPartnerAddress);
+                }
+                break;
+            case ACK:
+                if (connectionState == ConnectionState.SYN_RECEIVED) {
+                    connectionState = ConnectionState.CONNECTED;
+                    System.out.println("Verbindung hergestellt mit " + activeChatPartnerAddress);
+                }
+                break;
+            case FIN:
+                if (activeChatPartnerAddress != null && activeChatPartnerAddress.equals(source)) {
+                    try {
+                        sendControlPacket(FIN_ACK, partnerIp, partnerPort);
+                    } catch (IOException e) {
+                        // ignore
+                    }
+                    connectionState = ConnectionState.DISCONNECTED;
+                    activeChatPartnerAddress = null;
+                    System.out.println("Verbindung von " + source + " geschlossen.");
+                }
+                break;
+            case FIN_ACK:
+                if (connectionState == ConnectionState.FIN_WAIT) {
+                    connectionState = ConnectionState.DISCONNECTED;
+                    activeChatPartnerAddress = null;
+                    System.out.println("Verbindung geschlossen.");
+                }
+                break;
+            case MESSAGE:
+                if (packet.getPayload() instanceof MessagePayload) {
+                    MessagePayload mp = (MessagePayload) packet.getPayload();
+                    System.out.println("Nachricht empfangen: " + mp.getMessageText());
+                }
+                break;
+            default:
+                break;
+        }
     }
 }

--- a/src/packet/ConnectionState.java
+++ b/src/packet/ConnectionState.java
@@ -1,0 +1,9 @@
+package packet;
+
+public enum ConnectionState {
+    DISCONNECTED,
+    SYN_SENT,
+    SYN_RECEIVED,
+    CONNECTED,
+    FIN_WAIT
+}

--- a/src/udpSocket/UdpReceiver.java
+++ b/src/udpSocket/UdpReceiver.java
@@ -1,8 +1,8 @@
 package udpSocket;
 
-import packet.MessagePayload;
 import packet.Packet;
 import packet.PacketHeader;
+import packet.ChatApp;
 import routing.RoutingManager;
 
 import java.io.IOException;
@@ -17,11 +17,13 @@ public class UdpReceiver {
     private final DatagramSocket socket;
     private final ExecutorService executorService;
     private final RoutingManager routingManager;
+    private final ChatApp chatApp;
 
-    public UdpReceiver(DatagramSocket socket, int threadPoolSize, RoutingManager routingManager) {
+    public UdpReceiver(DatagramSocket socket, int threadPoolSize, RoutingManager routingManager, ChatApp chatApp) {
         this.socket = socket;
         this.executorService = Executors.newFixedThreadPool(threadPoolSize);
         this.routingManager = routingManager;
+        this.chatApp = chatApp;
     }
 
     public void start() {
@@ -56,18 +58,9 @@ public class UdpReceiver {
             boolean isForMe =
                     header.getDestIp().equals(localAddress) &&
                             header.getDestPort() + 1 == localPort;
-            System.out.println(header.getDestIp() + ":" + localPort);
-            System.out.println(header.getDestPort() + 1 + ":" + localAddress);
-
 
             if (isForMe) {
-                // Handle Packet
-                if (receivedPacket.getPayload() instanceof MessagePayload) {
-                    MessagePayload mp = (MessagePayload) receivedPacket.getPayload();
-                    System.out.println("Nachricht empfangen: " + mp.getMessageText());
-                } else {
-                    System.out.println("Empfangenes Payload: " + receivedPacket.getPayload().toString());
-                }
+                chatApp.onPacketReceived(receivedPacket);
             } else {
                 // Weiterleiten
                 System.out.println("Paket nicht für mich – Weiterleitung an " +


### PR DESCRIPTION
## Summary
- manage connections with new `ConnectionState`
- initiate SYN/SYN_ACK/ACK handshake on `/chat` or when sending messages to a new peer
- close sessions via FIN/FIN_ACK when quitting
- route incoming handshake packets through `UdpReceiver` to `ChatApp`

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68713f0fe2a88329b9bac635bfb3d25f